### PR TITLE
♻️ feat: include the "complex" code. task 2.3 CHAT GPT Lab

### DIFF
--- a/code_snippets/thien_atomicBool.go
+++ b/code_snippets/thien_atomicBool.go
@@ -1,0 +1,34 @@
+package util
+
+import (
+	"sync/atomic"
+)
+
+func convertBoolToInt32(b bool) int32 {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+// AtomicBool is a boxed-class that provides synchronized access to the
+// underlying boolean value
+type AtomicBool struct {
+	state int32 // "1" is true, "0" is false
+}
+
+// NewAtomicBool returns a new AtomicBool
+func NewAtomicBool(initialState bool) *AtomicBool {
+	return &AtomicBool{state: convertBoolToInt32(initialState)}
+}
+
+// Get returns the current boolean value synchronously
+func (a *AtomicBool) Get() bool {
+	return atomic.LoadInt32(&a.state) == 1
+}
+
+// Set updates the boolean value synchronously
+func (a *AtomicBool) Set(newState bool) bool {
+	atomic.StoreInt32(&a.state, convertBoolToInt32(newState))
+	return newState
+}

--- a/code_snippets/thien_atomicBool.go
+++ b/code_snippets/thien_atomicBool.go
@@ -4,31 +4,34 @@ import (
 	"sync/atomic"
 )
 
-func convertBoolToInt32(b bool) int32 {
+// boolToInt32 converts a boolean value to an int32 representation,
+// where true is represented as 1 and false as 0. This is used for atomic
+// operations on boolean values.
+func boolToInt32(b bool) int32 {
 	if b {
 		return 1
 	}
 	return 0
 }
 
-// AtomicBool is a boxed-class that provides synchronized access to the
-// underlying boolean value
+// AtomicBool provides an atomic boolean type, allowing for safe concurrent
+// access and modification of a boolean value.
 type AtomicBool struct {
 	state int32 // "1" is true, "0" is false
 }
 
-// NewAtomicBool returns a new AtomicBool
+// NewAtomicBool initializes a new AtomicBool with the given initial state.
 func NewAtomicBool(initialState bool) *AtomicBool {
-	return &AtomicBool{state: convertBoolToInt32(initialState)}
+	return &AtomicBool{state: boolToInt32(initialState)}
 }
 
-// Get returns the current boolean value synchronously
+// Get atomically retrieves the current value of the boolean.
 func (a *AtomicBool) Get() bool {
 	return atomic.LoadInt32(&a.state) == 1
 }
 
-// Set updates the boolean value synchronously
-func (a *AtomicBool) Set(newState bool) bool {
-	atomic.StoreInt32(&a.state, convertBoolToInt32(newState))
-	return newState
+// Set atomically updates the boolean value. The return value has been removed
+// as it's typically not needed for a setter and it was merely echoing the input value.
+func (a *AtomicBool) Set(newState bool) {
+	atomic.StoreInt32(&a.state, boolToInt32(newState))
 }


### PR DESCRIPTION
GYAT. Resolve #47 

Potential Areas for Improvement:

- [x] Documentation: The code needs some explanation for others as to why using `int32` for representing boolean values (hence the name, AtomicBool), detailed documentation is needed.
- [x] Naming convention: The function convertBoolToInt32 is unexported (private), which is good since it's an implementation detail. But we need better context.
- [x] Return Value of Set Method: The Set method's return value might be unnecessary since it merely echoes the input. but this is a setters 😱😱